### PR TITLE
Remove bootstrap-os role and confirmation task in remove-node playbook

### DIFF
--- a/remove-node.yml
+++ b/remove-node.yml
@@ -2,27 +2,11 @@
 - name: Check ansible version
   import_playbook: ansible_version.yml
 
-- hosts: "{{ node | default('etcd:k8s-cluster:calico-rr') }}"
-  gather_facts: no
-  environment: "{{ proxy_disable_env }}"
-  vars_prompt:
-    name: "delete_nodes_confirmation"
-    prompt: "Are you sure you want to delete nodes state? Type 'yes' to delete nodes."
-    default: "no"
-    private: no
-
-  pre_tasks:
-    - name: check confirmation
-      fail:
-        msg: "Delete nodes confirmation failed"
-      when: delete_nodes_confirmation != "yes"
-
 - hosts: kube-master[0]
   gather_facts: no
   environment: "{{ proxy_disable_env }}"
   roles:
     - { role: kubespray-defaults }
-    - { role: bootstrap-os, tags: bootstrap-os }
     - { role: remove-node/pre-remove, tags: pre-remove }
 
 - hosts: "{{ node | default('kube-node') }}"
@@ -30,7 +14,6 @@
   environment: "{{ proxy_disable_env }}"
   roles:
     - { role: kubespray-defaults, when: reset_nodes|default(True)|bool }
-    - { role: bootstrap-os, tags: bootstrap-os, when: reset_nodes|default(True)|bool }
     - { role: remove-node/remove-etcd-node }
     - { role: reset, tags: reset, when: reset_nodes|default(True)|bool }
 
@@ -40,5 +23,4 @@
   environment: "{{ proxy_disable_env }}"
   roles:
     - { role: kubespray-defaults, when: reset_nodes|default(True)|bool }
-    - { role: bootstrap-os, tags: bootstrap-os, when: reset_nodes|default(True)|bool }
     - { role: remove-node/post-remove, tags: post-remove }


### PR DESCRIPTION
Remove bootstrap-os role and confirmation task in remove-node playbook.

Kubespray issue: https://github.com/kubernetes-sigs/kubespray/issues/7569