### PR TITLE
Determine root filesistem device and partition before running growpart

### DIFF
--- a/roles/kubernetes/preinstall/tasks/0120-growpart-azure-centos-7.yml
+++ b/roles/kubernetes/preinstall/tasks/0120-growpart-azure-centos-7.yml
@@ -7,8 +7,17 @@
     name: cloud-utils-growpart
     state: present
 
+- name: Search root filesystem device
+  vars:
+    query: "[?mount=='/'].device"
+    _root_device: "{{ ansible_mounts|json_query(query) }}"
+  set_fact:
+    device: "{{ _root_device | first | regex_replace('([^0-9]+)[0-9]+', '\\1') }}"
+    partition: "{{ _root_device | first | regex_replace('[^0-9]+([0-9]+)', '\\1') }}"
+    root_device: "{{ _root_device }}"
+
 - name: check if growpart needs to be run
-  command: growpart -N /dev/sda 1
+  command: growpart -N {{ device }} {{ partition }}
   failed_when: False
   changed_when: "'NOCHANGE:' not in growpart_needed.stdout"
   register: growpart_needed
@@ -16,16 +25,16 @@
     LC_ALL: C
 
 - name: check fs type
-  command: file -Ls /dev/sda1
+  command: file -Ls {{ root_device }}
   changed_when: False
   register: fs_type
 
 - name: run growpart  # noqa 503
-  command: growpart /dev/sda 1
+  command: growpart {{ device }} {{ partition }}
   when: growpart_needed.changed
   environment:
     LC_ALL: C
 
 - name: run xfs_growfs  # noqa 503
-  command: xfs_growfs /dev/sda1
+  command: xfs_growfs {{ root_device }}
   when: growpart_needed.changed and 'XFS' in fs_type.stdout


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->
Already merged on kubespray: https://github.com/kubernetes-sigs/kubespray/pull/8024

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
When running on Azure it determines root filesystem device and partition to run `growpart` instead of assuming it will always be `/dev/sda1`

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7958 

**Special notes for your reviewer**: We use `terraform` to deploy Azure environments with several disks on each VM. It often happens that a device other than `/dev/sda1` is the root filesystem device on several VMs, maybe due to race conditions when deploying Azure disks and attaching them to VMs.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Determine root filesistem device and partition before running growpart (allowing to not always be sda1)
```
