### PR TITLE
[PLT-4195] Skip Enable RHEL 8 repos task when rhel_enable_repos is false

### DIFF
--- a/roles/bootstrap-os/tasks/rhel.yml
+++ b/roles/bootstrap-os/tasks/rhel.yml
@@ -71,6 +71,7 @@
     state: "{{ 'enabled' if (rhel_enable_repos | default(True) | bool) else 'disabled' }}"
   when:
     - ansible_distribution_major_version == "8"
+    - rhel_enable_repos | default(True) | bool
     - (not rh_subscription_status.changed) or (rh_subscription_username is defined) or (rh_subscription_org_id is defined)
 
 - name: Check presence of fastestmirror.conf


### PR DESCRIPTION
## Summary

- The `Enable RHEL 8 repos` task in `roles/bootstrap-os/tasks/rhel.yml` calls `community.general.rhsm_repository`, which invokes `subscription-manager` internally even when `state: disabled`.
- On systems that have the `subscription-manager` binary installed but no active Red Hat subscription, this causes the task to fail even when `rhel_enable_repos: false` is set via `override_vars`.
- Fix: add `rhel_enable_repos | default(True) | bool` to the `when` clause so the task is skipped entirely when repos are disabled, avoiding any call to `subscription-manager`.

## Test plan

- [ ] Upgrade on a RHEL 8 node with `rhel_enable_repos: false` and `subscription-manager` installed but no active subscription — task should be skipped with no error.
- [ ] Upgrade on a RHEL 8 node with `rhel_enable_repos: true` (or unset) and a valid subscription — task should run as before.

Reported in: SS-151162

🤖 Generated with [Claude Code](https://claude.com/claude-code)