### PR TITLE
[PLT-4264] Bump CoreDNS to v1.13.2 for Kubernetes 1.35

### DIFF
--- a/roles/kubespray-defaults/defaults/main/download.yml
+++ b/roles/kubespray-defaults/defaults/main/download.yml
@@ -316,7 +316,7 @@ haproxy_image_tag: 2.8.2-alpine
 # Coredns version should be supported by corefile-migration (or at least work with)
 # bundle with kubeadm; if not 'basic' upgrade can sometimes fail
 
-coredns_version: "{{ 'v1.13.1' if (kube_version is version('v1.35.0', '>=')) else 'v1.11.1' if (kube_version is version('v1.29.0', '>=')) else 'v1.10.1' }}"
+coredns_version: "{{ 'v1.13.2' if (kube_version is version('v1.35.0', '>=')) else 'v1.11.1' if (kube_version is version('v1.29.0', '>=')) else 'v1.10.1' }}"
 coredns_image_is_namespaced: "{{ (coredns_version is version('v1.7.1', '>=')) }}"
 
 coredns_image_repo: "{{ kube_image_repo }}{{ '/coredns/coredns' if (coredns_image_is_namespaced | bool) else '/coredns' }}"


### PR DESCRIPTION
## Summary

- Bumps CoreDNS from `v1.13.1` to `v1.13.2` for Kubernetes >= 1.35
- `v1.13.1` is the K8s 1.35 kubeadm default; `v1.13.2` is a patch release with no breaking changes

## Changes

- Performance improvements and reduced allocations
- Initial DoH3 (DNS over HTTP/3) support
- Race condition fix in the `uniq` plugin
- `v1.13.1` and `v1.13.2` for older K8s versions remain unchanged

## Test plan

- [ ] Deploy cluster with K8s 1.35 and verify CoreDNS pod starts with `v1.13.2`
- [ ] Verify DNS resolution works after upgrade from v1.13.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)