### PR TITLE
Fix CoreDNS version for k8s 1.35: v1.13.2 → v1.13.1

### DIFF
--- a/roles/kubespray-defaults/defaults/main/download.yml
+++ b/roles/kubespray-defaults/defaults/main/download.yml
@@ -316,7 +316,7 @@ haproxy_image_tag: 2.8.2-alpine
 # Coredns version should be supported by corefile-migration (or at least work with)
 # bundle with kubeadm; if not 'basic' upgrade can sometimes fail
 
-coredns_version: "{{ 'v1.13.2' if (kube_version is version('v1.35.0', '>=')) else 'v1.11.1' if (kube_version is version('v1.29.0', '>=')) else 'v1.10.1' }}"
+coredns_version: "{{ 'v1.13.1' if (kube_version is version('v1.35.0', '>=')) else 'v1.11.1' if (kube_version is version('v1.29.0', '>=')) else 'v1.10.1' }}"
 coredns_image_is_namespaced: "{{ (coredns_version is version('v1.7.1', '>=')) }}"
 
 coredns_image_repo: "{{ kube_image_repo }}{{ '/coredns/coredns' if (coredns_image_is_namespaced | bool) else '/coredns' }}"


### PR DESCRIPTION
## Summary

- Downgrade default CoreDNS version for k8s >= 1.35 from `v1.13.2` to `v1.13.1`

## Root cause

kubeadm v1.35.x ships with `corefile-migration v1.0.29`, which supports CoreDNS migrations up to **v1.13.1**. Using v1.13.2 causes `kubeadm upgrade apply` to fail on the last control-plane node (the only one that actually runs the `addon/coredns` phase, since kubeadm skips it when other CPs are still pending):

```
error: error execution phase addon/coredns: unable to get list of changes to the configuration.: start version '1.13.2' not supported
```

## Fix

Set CoreDNS default to `v1.13.1` for k8s >= 1.35, which is the maximum version supported by the corefile-migration library bundled with kubeadm v1.35.x.

🤖 Generated with [Claude Code](https://claude.com/claude-code)